### PR TITLE
fix: correct renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,9 @@
   "argocd": {
     "fileMatch": ["argo-cd/.+\\.yaml$"]
   },
+  "helm-values": {
+    "enabled": false
+  },
   "extends": [
     "config:base",
     ":timezone(Asia/Tokyo)",
@@ -18,9 +21,6 @@
     ":automergePatch"
   ],
   "automerge": true,
-  "ignoreDeps": [
-    "helm-values"
-  ],
   "ignorePaths": [
     "argo-cd/base"
   ],


### PR DESCRIPTION
## Summary
- Disable helm-values manager in renovate config
- Fix automerge typo in extends (automergePatch)
- Replace packageRules with ignorePaths for argo-cd/base